### PR TITLE
When using the compiled JavaScript I was getting some type issues wit…

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,5 @@
-import {Injectable, provide} from 'angular2/core';
-import {RequestOptionsArgs} from 'angular2/http';
+import {Injectable, Injector, provide} from 'angular2/core';
+import {Http, RequestOptionsArgs} from 'angular2/http';
 import {Shared} from './shared';
 import {Local} from './local';
 import {Oauth} from './oauth';
@@ -14,9 +14,15 @@ import {Config} from './config';
  * Created by Ron on 17/12/2015.
  */
 export function SATELLIZER_PROVIDERS(config: ICustomConfig) {
-    return [provide(Config, { useFactory: () => {
-        return new Config(config);
-    }}), Auth, Oauth, Oauth1, Oauth2, Local, Shared, Popup, Storage];
+    return [provide(Config, { useFactory: () => { return new Config(config);}}), 
+            provide(Storage, { useFactory: (providedConfig) => { return new Storage(providedConfig);}, deps: [Config]} ), 
+            provide(Shared, { useFactory: (storage, providedConfig) => { return new Shared(storage, providedConfig);}, deps: [Storage, Config]} ), 
+            provide(Oauth, { useFactory: (http, injector, providedConfig, storage) => { return new Oauth(http, injector, providedConfig, storage);}, deps: [Http, Injector, Config, Storage]} ), 
+            provide(Popup, { useFactory: (providedConfig) => { return new Popup(providedConfig);}, deps: [Config]} ),
+            provide(Oauth1, { useFactory: (http, popup, providedConfig) => { return new Oauth1(http, popup, providedConfig);}, deps: [Http, Popup, Config]} ),
+            provide(Oauth2, { useFactory: (http, popup, storage, providedConfig) => { return new Oauth2(http, popup, storage, providedConfig);}, deps: [Http, Popup, Storage, Config]} ),
+            provide(Local, { useFactory: (http, shared, providedConfig) => { return new Local(http, shared, providedConfig);}, deps: [Http, Shared, Config]} ),
+            provide(Auth, { useFactory: (shared, local, oauth) => { return new Auth(shared, local, oauth);}, deps: [Shared, Local, Oauth]} )];
 }
 @Injectable()
 export class Auth {


### PR DESCRIPTION
…h the dependency injection.

I'm not 100% sure, but the description of the problem in this blog led me to the current solution
http://blog.thoughtram.io/angular/2015/09/03/forward-references-in-angular-2.html
I think the problem is the classes were being used as keys, before they were declared. Of course if that is the case, just re-arranging should have worked but I needed to change everything to explicit factories too.